### PR TITLE
Fix performance of `DecEq-×`

### DIFF
--- a/Class/DecEq/Instances.agda
+++ b/Class/DecEq/Instances.agda
@@ -54,8 +54,12 @@ module _ ⦃ _ : DecEq A ⦄ where instance
 module _ ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
 
   -- Not exported as instance so that users can also choose `Class.DecEq.WithK.DecEq-Σ`
+
+  -- For performance reasons, this is not ×.≡-dec. `(a₁ , b₁) ≡ᵇ (a₂ , b₂)` should reduce
+  -- to `a₁ ≡ᵇ a₂ ∧ b₁ ≡ᵇ b₂`, which the definition below does, but `×.≡-dec` would also
+  -- match on the proof of `a₁ ≡ a₂`, which may force huge proof terms.
   DecEq-× : DecEq (A × B)
-  DecEq-× ._≟_ = ×.≡-dec _≟_ _≟_
+  DecEq-× ._≟_ (a₁ , b₁) (a₂ , b₂) = mapDec ×.×-≡,≡→≡ ×.×-≡,≡←≡ (a₁ ≟ a₂ ×-dec b₁ ≟ b₂)
     where import Data.Product.Properties as ×
 
   instance

--- a/Class/Prelude.agda
+++ b/Class/Prelude.agda
@@ -76,7 +76,7 @@ open Meta public
 open import Relation.Nullary public
   using (¬_; Dec; yes; no; contradiction; Irrelevant)
 open import Relation.Nullary.Decidable public
-  using (⌊_⌋; dec-yes; isYes)
+  using (⌊_⌋; dec-yes; isYes; _×-dec_)
   renaming (map′ to mapDec)
 open import Relation.Unary public
   using (Pred)


### PR DESCRIPTION
The old definition normalises the proof of the first component of the pair all the way down to `refl`. You can see this via the following snippet:

```agda
instance _ = DecEq-×
n = quote ℕ

test : ((n , 0) ≡ᵇ (n , 0)) ≡ true
test = refl
```

With the old definition, I didn't have the patience to wait, but I'm pretty sure it's not going to finish before OOM no matter what. With the new definition it's instant.

The reason is that `DecEq-Name` is defined via `primQNameToWord64s`, which returns a pair of `Word64`, the first being quite small and the second being very large. This equality is defined in terms of `_≟_ : DecidableEquality ℕ` from `Data.Nat.Properties`, which as the comment there acknowledges takes a linear amount of time to force down to `refl`.

Note that this speedup should apply pretty much everywhere `DecEq-×` is used. The old definition _always_ forced the `refl` in the first component, the new one only forces it if you force the whole thing. The `Name` is just a particularly easy way to demonstrate this, as well as where it first appeared in practice.

See also https://github.com/agda/agda-stdlib-meta/pull/42